### PR TITLE
Enable all artifacts generated at specific directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,22 @@ include(Options.cmake)
 
 # env
 set(LGRAPH_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
-set(DEPS_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/install/include)
-set(DEPS_LIBRARY_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/install/lib)
-set(DEPS_LIBRARY64_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/install/lib64)
+# if DEPS_INCLUDE_DIR not set, use default
+if (NOT DEPS_INCLUDE_DIR)
+    set(DEPS_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/install/include)
+endif ()
+message(STATUS "DEPS_INCLUDE_DIR: ${DEPS_INCLUDE_DIR}")
+# if DEPS_LIBRARY_DIR not set, use default
+if (NOT DEPS_LIBRARY_DIR)
+    set(DEPS_LIBRARY_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/install/lib)
+endif ()
+message(STATUS "DEPS_LIBRARY_DIR: ${DEPS_LIBRARY_DIR}")
+# if DEPS_LIBRARY64_DIR not set, use default
+if (NOT DEPS_LIBRARY64_DIR)
+    set(DEPS_LIBRARY64_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/install/lib64)
+endif ()
+message(STATUS "DEPS_LIBRARY64_DIR: ${DEPS_LIBRARY64_DIR}")
+
 set(LGRAPH_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
 set(CMAKEFILES_COMPILER_DIR ${PROJECT_BINARY_DIR})
 set(DEPS_LOCAL_INCLUDE_DIR /usr/local/include)

--- a/src/BuildClients.cmake
+++ b/src/BuildClients.cmake
@@ -12,7 +12,7 @@ endif ()
 
 # protbuf
 include(cmake/GenerateProtobuf.cmake)
-GenerateProtobufCpp(${CMAKE_CURRENT_LIST_DIR}/protobuf
+GenerateProtobufCpp(${CMAKE_CURRENT_BINARY_DIR}/protobuf
         PROTO_SRCS PROTO_HEADERS
         ${CMAKE_CURRENT_LIST_DIR}/protobuf/ha.proto)
 
@@ -40,7 +40,8 @@ target_include_directories(${TARGET_CPP_CLIENT_RPC} PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/cypher    # for FieldDataConvert
         ${LGRAPH_INCLUDE_DIR}
-        ${JNI_INCLUDE_DIRS})
+        ${JNI_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_BINARY_DIR})
 
 if (NOT (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
     target_link_libraries(${TARGET_CPP_CLIENT_RPC}
@@ -118,7 +119,8 @@ target_include_directories(${TARGET_CPP_CLIENT_REST} PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/cypher
         ${LGRAPH_INCLUDE_DIR}
-        ${JNI_INCLUDE_DIRS})
+        ${JNI_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_BINARY_DIR})
 
 ############### liblgraph_client_python ######################
 

--- a/src/BuildLGraphApi.cmake
+++ b/src/BuildLGraphApi.cmake
@@ -19,11 +19,13 @@ endif ()
 include(cmake/GenerateVersionInfo.cmake)
 GenerateVersionInfo(${LGRAPH_VERSION_MAJOR} ${LGRAPH_VERSION_MINOR} ${LGRAPH_VERSION_PATCH}
         ${CMAKE_CURRENT_LIST_DIR}/core/version.h.in
-        ${CMAKE_CURRENT_LIST_DIR}/core/version.h)
+        ${CMAKE_CURRENT_BINARY_DIR}/core/version.h)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # protbuf
 include(cmake/GenerateProtobuf.cmake)
-GenerateProtobufCpp(${CMAKE_CURRENT_LIST_DIR}/protobuf
+GenerateProtobufCpp(${CMAKE_CURRENT_BINARY_DIR}/protobuf
         PROTO_SRCS PROTO_HEADERS
         ${CMAKE_CURRENT_LIST_DIR}/protobuf/ha.proto)
 
@@ -100,7 +102,8 @@ target_include_directories(${TARGET_LGRAPH} PUBLIC
         ${LGRAPH_INCLUDE_DIR}
         ${LGRAPH_SRC_DIR}
         ${LGRAPH_SRC_DIR}/cypher
-        ${JNI_INCLUDE_DIRS})
+        ${JNI_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_BINARY_DIR})
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_link_libraries(${TARGET_LGRAPH} PUBLIC

--- a/src/BuildLGraphServer.cmake
+++ b/src/BuildLGraphServer.cmake
@@ -26,7 +26,7 @@ find_package(OpenSSL)
 
 # protbuf
 include(cmake/GenerateProtobuf.cmake)
-GenerateProtobufCpp(${CMAKE_CURRENT_LIST_DIR}/protobuf
+GenerateProtobufCpp(${CMAKE_CURRENT_BINARY_DIR}/protobuf
         PROTO_SRCS PROTO_HEADERS
         ${CMAKE_CURRENT_LIST_DIR}/protobuf/ha.proto)
 


### PR DESCRIPTION
Before this PR,  **deps/build_deps.sh** emits all artifacts in deps/build and there is no option to change the location. Also, the generated **ha.pb.cc, ha.pb.h, version.h** are at the source tree instead of the build tree. 

Here two cons:
 - Cannot remove all artifacts in one *basket*.
 - Some automate system(e.g. rust doc build system) has **no write permission** of source tree during build process.
 
This PR doesn't make effect on the build process but provide some option to specify emitting location. In the other words, you can build as before. All changes can be described as following:
- Provide a `-o <output_dir>` option for deps/build_deps.sh, so that the *build* and the *install* can be at the user-specific location.
- `DEPS_INCLUDE_DIR, DEPS_LIBRARY_DIR,  DEPS_LIBRARY64_DIR` in src/CMakeLists.txt can be configured in args.
- Generate *pbs and version.h* at the build tree instead of the source tree