### PR TITLE
support codescan before merge master

### DIFF
--- a/.github/workflows/cloud_code_scan.yml
+++ b/.github/workflows/cloud_code_scan.yml
@@ -1,6 +1,6 @@
 name: Alipay Cloud Devops Codescan
 on:
-  push:
+  pull_request_target:
 
 jobs:
   deployment:

--- a/.github/workflows/cloud_code_scan.yml
+++ b/.github/workflows/cloud_code_scan.yml
@@ -1,5 +1,6 @@
 name: Alipay Cloud Devops Codescan
 on:
+  pull_request:
   pull_request_target:
 
 jobs:

--- a/.github/workflows/cloud_code_scan.yml
+++ b/.github/workflows/cloud_code_scan.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: codeScan
-        if: ${{ github.repository == 'TuGraph-family/tugraph-db' }}
         uses: TuGraph-family/alipay-cloud-devops-codescan@main
         with:
           parent_uid: ${{ secrets.ALI_PID }}

--- a/ci/github_ci.sh
+++ b/ci/github_ci.sh
@@ -2,6 +2,7 @@
 set -e
 
 ASAN=$1
+WITH_PROCEDURE=${2:-"OFF"}
 
 cd $WORKSPACE
 
@@ -17,9 +18,9 @@ cd $WORKSPACE
 mkdir build && cd build
 if [[ "$ASAN" == "asan" ]]; then
 echo 'build with asan ...'
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DBUILD_PROCEDURE=$WITH_PROCEDURE
 else
-cmake .. -DCMAKE_BUILD_TYPE=Coverage
+cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PROCEDURE=$WITH_PROCEDURE
 fi
 make -j2
 make unit_test fma_unit_test -j2
@@ -66,6 +67,9 @@ cp ../../src/client/python/TuGraphClient/TuGraphRestClient.py .
 cp -r ../../test/integration/* ./
 cp -r ../../learn/examples/* ./
 cp -r ../../demo/movie .
+if [[ "$WITH_PROCEDURE" == "OFF" ]]; then
+    rm -rf test_algo.py test_sampling.py test_train.py
+fi
 pytest ./
 
 # codecov


### PR DESCRIPTION
Codescan is a component from Mini Program Cloud and requires the secret variable of TuGrpah-family. Previously it could only be triggered after merge. Now the trigger conditions are modified to trigger before merge.