### PR TITLE
skip procedure build it & make codescan triggered by pull request target

### DIFF
--- a/.github/workflows/cloud_code_scan.yml
+++ b/.github/workflows/cloud_code_scan.yml
@@ -1,6 +1,6 @@
 name: Alipay Cloud Devops Codescan
 on:
-  push:
+  pull_request_target:
 
 jobs:
   deployment:

--- a/ci/github_ci.sh
+++ b/ci/github_ci.sh
@@ -2,6 +2,7 @@
 set -e
 
 ASAN=$1
+WITH_PROCEDURE=${2:-"OFF"}
 
 cd $WORKSPACE
 
@@ -17,9 +18,9 @@ cd $WORKSPACE
 mkdir build && cd build
 if [[ "$ASAN" == "asan" ]]; then
 echo 'build with asan ...'
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DBUILD_PROCEDURE=$WITH_PROCEDURE
 else
-cmake .. -DCMAKE_BUILD_TYPE=Coverage
+cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PROCEDURE=$WITH_PROCEDURE
 fi
 make -j2
 make unit_test fma_unit_test -j2
@@ -66,6 +67,9 @@ cp ../../src/client/python/TuGraphClient/TuGraphRestClient.py .
 cp -r ../../test/integration/* ./
 cp -r ../../learn/examples/* ./
 cp -r ../../demo/movie .
+if [[ "$WITH_PROCEDURE" == "OFF" ]]; then
+    rm -rf test_algo.py test_sampling.py test_train.py
+fi
 pytest ./
 
 # codecov


### PR DESCRIPTION
1. Due to the resource limitations of GitHub CI and the fact that the procedure module does not change frequently, the compilation and integration testing of the procedure module are skipped by default.
2. The codescan component supports pull request target triggering to perform security reviews before code integration.