### PR TITLE
fix issue 333 (update doc gen)

### DIFF
--- a/docs/en-US/source/conf.py
+++ b/docs/en-US/source/conf.py
@@ -32,9 +32,9 @@ html_theme = 'sphinx_rtd_theme'
 
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/tugraph-3.5.0/liblgraph_python_api.so"))
-    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/tugraph-3.5.0/liblgraph.so"))
-    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/tugraph-3.5.0/libjvm.so"))
+    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/doc_deps/liblgraph_python_api.so"))
+    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/doc_deps/liblgraph.so"))
+    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/doc_deps/libjvm.so"))
     sys.path.insert(0, os.path.abspath('5.developer-manual/6.interface/3.procedure/'))
     # doxygen & breathe
     extensions.append("breathe")
@@ -42,5 +42,9 @@ if read_the_docs_build:
     breathe_projects = {"cpp_procedure": "5.developer-manual/6.interface/3.procedure/build/xml"}
     breathe_default_project = "cpp_procedure"
 else:
-    subprocess.run(shlex.split("rm -rf 3.C++-procedure 4.Python-procedure.rst index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")
-    subprocess.run(shlex.split("mv index.rst.aci index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")
+    if os.path.exists("5.developer-manual/6.interface/3.procedure/3.C++-procedure") and \
+            os.path.exists("5.developer-manual/6.interface/3.procedure/4.Python-procedure.rst") and \
+            os.path.exists("5.developer-manual/6.interface/3.procedure/index.rst") and \
+            os.path.exists("5.developer-manual/6.interface/3.procedure/index.rst.aci"):
+        subprocess.run(shlex.split("rm -rf 3.C++-procedure 4.Python-procedure.rst index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")
+        subprocess.run(shlex.split("mv index.rst.aci index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")

--- a/docs/zh-CN/source/conf.py
+++ b/docs/zh-CN/source/conf.py
@@ -31,9 +31,9 @@ html_theme = 'sphinx_rtd_theme'
 
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/tugraph-3.5.0/liblgraph_python_api.so"))
-    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/tugraph-3.5.0/liblgraph.so"))
-    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/tugraph-3.5.0/libjvm.so"))
+    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/doc_deps/liblgraph_python_api.so"))
+    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/doc_deps/liblgraph.so"))
+    subprocess.run(shlex.split("wget https://tugraph-web.oss-cn-beijing.aliyuncs.com/tugraph/doc_deps/libjvm.so"))
     sys.path.insert(0, os.path.abspath('5.developer-manual/6.interface/3.procedure/'))
     # doxygen & breathe
     extensions.append("breathe")
@@ -41,5 +41,9 @@ if read_the_docs_build:
     breathe_projects = {"cpp_procedure": "5.developer-manual/6.interface/3.procedure/build/xml"}
     breathe_default_project = "cpp_procedure"
 else:
-    subprocess.run(shlex.split("rm -rf 3.C++-procedure 4.Python-procedure.rst index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")
-    subprocess.run(shlex.split("mv index.rst.aci index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")
+    if os.path.exists("5.developer-manual/6.interface/3.procedure/3.C++-procedure") and \
+            os.path.exists("5.developer-manual/6.interface/3.procedure/4.Python-procedure.rst") and \
+            os.path.exists("5.developer-manual/6.interface/3.procedure/index.rst") and \
+            os.path.exists("5.developer-manual/6.interface/3.procedure/index.rst.aci"):
+        subprocess.run(shlex.split("rm -rf 3.C++-procedure 4.Python-procedure.rst index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")
+        subprocess.run(shlex.split("mv index.rst.aci index.rst"), cwd="5.developer-manual/6.interface/3.procedure/")


### PR DESCRIPTION
Fix document generation logic:
1. Judge before deleting files. Document generation can be executed repeatedly in both the local environment and read_the_docs environment.
2. Change the doc generation dependency folder to doc_deps and delete the hard-coded 3.5.0