### PR TITLE
modify ha leader check

### DIFF
--- a/src/server/ha_state_machine.h
+++ b/src/server/ha_state_machine.h
@@ -56,8 +56,6 @@ class HaStateMachine : public StateMachine, public braft::StateMachine {
     mutable std::mutex hb_mutex_;
     std::condition_variable hb_cond_;
     bool exit_flag_ = false;  // should heartbeat thread exit?
-    NodeState node_state_;    // state of current node
-    bool peers_changed_;
     struct HeartbeatStatus {
         std::string rpc_addr;
         std::string rest_addr;
@@ -80,9 +78,7 @@ class HaStateMachine : public StateMachine, public braft::StateMachine {
           node_(nullptr),
           leader_term_(-1),
           joined_group_(false),
-          config_(config),
-          node_state_(NodeState::UNINITIALIZED),
-          peers_changed_(false) {
+          config_(config) {
         my_rest_addr_ =
             fma_common::StringFormatter::Format("{}:{}", config.host, global_config->http_port);
         my_rpc_addr_ = fma_common::StringFormatter::Format("{}:{}", config.host, config_.rpc_port);
@@ -173,6 +169,14 @@ class HaStateMachine : public StateMachine, public braft::StateMachine {
         google::protobuf::Closure* done_;
     };
 
+    struct SnapshotArg {
+        braft::SnapshotWriter* writer;
+        braft::Closure* done;
+        lgraph::HaStateMachine* haStateMachine;
+    };
+
+    static void *save_snapshot(void* arg);
+
     bool ReplicateAndApplyRequest(const LGraphRequest* req, LGraphResponse* resp,
                                   google::protobuf::Closure* on_done);
 
@@ -181,7 +185,7 @@ class HaStateMachine : public StateMachine, public braft::StateMachine {
 
     void HeartbeatThread();
 
-    void SendHeartbeatToMasterLocked(NodeState state);
+    void SendHeartbeatToMasterLocked();
     void ScanHeartbeatStatusLocked();
 };
 }  // namespace lgraph


### PR DESCRIPTION
本PR是修改TuGraph HA判断leader的逻辑。
- 原始方案：原来TuGraph HA的心跳逻辑是根据node_state确定当前node是leader还是follower，node_state是在braft回调on_leader_start函数时刷新的。
- 问题：on_leader_start，on_apply是在同一个执行队列中顺序执行的，如果leader切换到一个比较慢的follower上，他会先把堆积的log apply到state machine中，才会执行on_leader_start，这个时间间隔可能很长，即出现长时间HA找不到leader的情况，不过实际上此时leader已经选举出来了。
- 新方案：将通过node_state判断主从的方案修改为通过node->isLeader()判断，修改只在HA request上生效，即只有在查询ha info时生效，目前的修改方案在写请求到来时仍然会拒绝请求，避免日志的进一步堆积。