### PR TITLE
Fix errors when making the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,6 @@ if (BUILD_PROCEDURE)
 endif (BUILD_PROCEDURE)
 
 # unit_test
-add_subdirectory(test)
-set(LGRAPH_TOOLKITS lgraph_import lgraph_backup lgraph_warmup lgraph_peek lgraph_export lgraph_binlog lgraph_peer)
-add_dependencies(unit_test ${LGRAPH_TOOLKITS} lgraph_server)
-
-set_target_properties(unit_test PROPERTIES EXCLUDE_FROM_ALL TRUE)
-set_target_properties(fma_unit_test PROPERTIES EXCLUDE_FROM_ALL TRUE)
+if (WITH_TESTS)
+    add_subdirectory(test)
+endif (WITH_TESTS)

--- a/Options.cmake
+++ b/Options.cmake
@@ -91,6 +91,11 @@ if (BUILD_PROCEDURE)
     message("Build procedures.")
 endif (BUILD_PROCEDURE)
 
+option(WITH_TESTS "build with tests" ON)
+if (WITH_TESTS)
+    message("Build with tests.")
+endif (WITH_TESTS)
+
 # disable krb5
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOPENSSL_NO_KRB5=1")
 
@@ -189,4 +194,3 @@ if (ENABLE_PREDOWNLOAD_DEPENDS_PACKAGE)
     execute_process(COMMAND /bin/sh install.sh
             WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/src/python/FMA_shell/pkg)
 endif ()
-

--- a/ci/build_export.sh
+++ b/ci/build_export.sh
@@ -18,9 +18,9 @@ mkdir build && cd build
 # build cpp
 if [[ "$ASAN" == "asan" ]]; then
 echo 'build with asan ...'
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DBUILD_PROCEDURE=$WITH_PROCEDURE
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DBUILD_PROCEDURE=$WITH_PROCEDURE -DWITH_TEST=OFF
 else
-cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PROCEDURE=$WITH_PROCEDURE
+cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PROCEDURE=$WITH_PROCEDURE -DWITH_TEST=OFF
 fi
 
 make -j6

--- a/ci/build_release.sh
+++ b/ci/build_release.sh
@@ -23,5 +23,4 @@ else
 cmake .. -DCMAKE_BUILD_TYPE=Release
 fi
 
-make -j6
-
+make -j6 package

--- a/ci/github_ci.sh
+++ b/ci/github_ci.sh
@@ -23,11 +23,9 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DBUILD_PROCEDURE=$WITH_PROCE
 else
 cmake .. -DCMAKE_BUILD_TYPE=Coverage -DBUILD_PROCEDURE=$WITH_PROCEDURE
 fi
-make -j2
+make -j2 package
 
 if [[ "$TEST" == "ut" ]]; then
-  make unit_test fma_unit_test -j2
-
   # build tugraph db management
   cd $WORKSPACE/deps/tugraph-db-management/
   sh local_build.sh

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,7 +143,5 @@ target_link_libraries(unit_test
 
 target_compile_definitions(unit_test PRIVATE
         FMA_IN_UNIT_TEST=1)
-# install
-install(TARGETS unit_test
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib64)
+
+add_dependencies(unit_test ${LGRAPH_TOOLKITS} lgraph_server)


### PR DESCRIPTION
1.make: unit_test is created by default.
2.make package: unit_test is not included.
3.Set -DWITH_TESTS=OFF to compile without unit_test.