### PR TITLE
fix eid coredump

### DIFF
--- a/include/lgraph/lgraph_exceptions.h
+++ b/include/lgraph/lgraph_exceptions.h
@@ -74,7 +74,8 @@ X(EvaluationException, "Evaluation exception.") \
 X(TxnCommitException, "Txn commit exception.") \
 X(ReminderException, "Reminder exception.") \
 X(GraphCreateException, "Graph create exception.") \
-X(CypherParameterTypeError, "Cypher parameter type error.")
+X(CypherParameterTypeError, "Cypher parameter type error.") \
+X(ReachMaximumEid, "Edge eid exceeds the limit.")
 
 enum class ErrorCode {
 #define X(code, msg) code,

--- a/src/core/data_type.h
+++ b/src/core/data_type.h
@@ -295,7 +295,7 @@ static const size_t LID_SIZE = sizeof(LabelId);
 static const size_t TID_SIZE = sizeof(TemporalId);
 // maximum label id. -1 is reserved, so maximum is 65534
 static const int64_t MAX_VID = (((int64_t)1) << (VID_SIZE * 8)) - 2;
-static const int64_t MAX_EID = (((int64_t)1) << (EID_SIZE * 8)) - 2;
+static const int64_t MAX_EID = 0xffffff;  // 3 bytes
 static const int64_t MAX_TID = std::numeric_limits<TemporalId>::max() - 2;
 static const LabelId MAX_LID = std::numeric_limits<LabelId>::max() - 2;
 static const size_t NODE_SPLIT_THRESHOLD = 1000;
@@ -377,25 +377,29 @@ inline void SetOffset(char* offset_array, size_t i, size_t off) {
 
 inline void CheckVid(VertexId vid) {
     if (vid < 0 || vid > ::lgraph::_detail::MAX_VID) {
-        THROW_CODE(InputError, "vertex id out of range: must be a number between 0 and 1<<40 - 2");
+        THROW_CODE(InputError, "vertex id out of range: must be a number between 0 and {}",
+                   ::lgraph::_detail::MAX_VID);
     }
 }
 
 inline void CheckEid(EdgeId eid) {
     if (eid < 0 || eid > ::lgraph::_detail::MAX_EID) {
-        THROW_CODE(InputError, "edge id out of range: must be a number between 0 and 1<<32 - 2");
+        THROW_CODE(InputError, "edge id out of range: must be a number between 0 and {}",
+                   ::lgraph::_detail::MAX_EID);
     }
 }
 
 inline void CheckTid(TemporalId tid) {
     if (tid > ::lgraph::_detail::MAX_TID) {
-        THROW_CODE(InputError, "edge id out of range: must be a number between 0 and 1<<32 - 2");
+        THROW_CODE(InputError, "edge id out of range: must be a number between 0 and {}",
+                   ::lgraph::_detail::MAX_TID);
     }
 }
 
 inline void CheckLid(size_t lid) {
     if (lid > ::lgraph::_detail::MAX_LID) {
-        THROW_CODE(InputError, "label id out of range: must be a number between 0 and 65534");
+        THROW_CODE(InputError, "label id out of range: must be a number between 0 and {}",
+                   ::lgraph::_detail::MAX_LID);
     }
 }
 

--- a/src/core/graph_edge_iterator.h
+++ b/src/core/graph_edge_iterator.h
@@ -36,18 +36,18 @@ class Graph;
 namespace _detail {
 inline void StorePackedNode(KvIterator& it, VertexId vid, const PackedDataValue& pdv) {
     bool r = it.AddKeyValue(pdv.CreateKey(vid), pdv.GetBuf());
-    FMA_DBG_ASSERT(r);
+    FMA_ASSERT(r);
 }
 
 inline void StoreVertexOnlyNode(KvIterator& it, VertexId vid, const VertexValue& vov) {
     bool r = it.AddKeyValue(KeyPacker::CreateVertexOnlyKey(vid), vov.GetBuf(), false);
-    FMA_DBG_ASSERT(r);
+    FMA_ASSERT(r);
 }
 
 inline void StoreEdgeNode(PackType pt, KvIterator& it, VertexId vid1, const EdgeValue& ev) {
     if (ev.GetEdgeCount() == 0) return;
     bool r = it.AddKeyValue(ev.CreateKey(pt, vid1), ev.GetBuf(), false);
-    FMA_DBG_ASSERT(r);
+    FMA_ASSERT(r);
 }
 }  // namespace _detail
 
@@ -502,8 +502,8 @@ class EdgeIteratorImpl {
                     eid = 0;
                 }
             }
-            if (eid >= ::lgraph::_detail::MAX_EID)
-                throw std::runtime_error("Too many edges from src to dst with the same label");
+            if (eid > ::lgraph::_detail::MAX_EID)
+                THROW_CODE(ReachMaximumEid, "Too many edges from src to dst with the same label");
         }
         int64_t size_diff = ev.InsertAtPos(pos, esid.lid, esid.tid, esid.dst, eid, prop);
         if (pt == PackType::PACKED_DATA) {


### PR DESCRIPTION
边的 eid 的实际可存储值最大只能是 16777215，超过会溢出，引发coredump。
这个值可能不太合理，目前先限制死，避免coredump。