### PR TITLE
Optimize vertex label altering for detached model

### DIFF
--- a/src/core/lightning_graph.cpp
+++ b/src/core/lightning_graph.cpp
@@ -482,15 +482,17 @@ bool LightningGraph::_AlterLabel(
         } else {
             // scan and modify the vertexes
             std::unique_ptr<lgraph::graph::VertexIterator> vit(
-                new lgraph::graph::VertexIterator(graph_->GetUnmanagedVertexIterator(&txn.GetTxn())));
+                new graph::VertexIterator(graph_->GetUnmanagedVertexIterator(&txn.GetTxn())));
             while (vit->IsValid()) {
                 Value prop = vit->GetProperty();
                 if (curr_sm->GetRecordLabelId(prop) == curr_lid) {
                     modified++;
-                    Value new_prop = make_new_prop_and_destroy_old(prop, curr_schema, new_schema, txn);
+                    Value new_prop = make_new_prop_and_destroy_old(
+                        prop, curr_schema, new_schema, txn);
                     vit->RefreshContentIfKvIteratorModified();
                     if (curr_schema->DetachProperty()) {
-                        curr_schema->SetDetachedVertexProperty(txn.GetTxn(), vit->GetId(), new_prop);
+                        curr_schema->SetDetachedVertexProperty(
+                            txn.GetTxn(), vit->GetId(), new_prop);
                     } else {
                         vit->SetProperty(new_prop);
                     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,6 +129,7 @@ add_executable(unit_test
         test_ha_witness.cpp
         test_ha_full_import.cpp
         test_null_index.cpp
+        test_alter_detached_label.cpp
         ${LGRAPH_ROOT_DIR}/src/client/cpp/rpc/lgraph_rpc_client.cpp
         ${LGRAPH_ROOT_DIR}/src/client/cpp/restful/rest_client.cpp
         ${LGRAPH_ROOT_DIR}/src/import/import_client.cpp

--- a/test/test_alter_detached_label.cpp
+++ b/test/test_alter_detached_label.cpp
@@ -1,0 +1,22 @@
+/**
+* Copyright 2022 AntGroup CO., Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+#include "gtest/gtest.h"
+#include "./ut_utils.h"
+#include "lgraph/lgraph.h"
+#include "core/defs.h"
+#include "core/data_type.h"
+using namespace lgraph_api;
+
+class TestNullIndex : public TuGraphTest{};

--- a/test/test_alter_detached_label.cpp
+++ b/test/test_alter_detached_label.cpp
@@ -19,4 +19,147 @@
 #include "core/data_type.h"
 using namespace lgraph_api;
 
-class TestNullIndex : public TuGraphTest{};
+class TestAlterDetachedLabel : public TuGraphTest{};
+
+TEST_F(TestAlterDetachedLabel, vertex_add_field) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo;
+    vo.primary_field = "id";
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
+                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                             {"str", FieldType::STRING, true},
+                                                             {"int64", FieldType::INT64, true}}),
+                                     vo));
+
+
+    std::vector<std::string> vp({"id", "str", "int64"});
+    std::vector<std::pair<int64_t, int32_t>> check;
+    int count = 10000;
+    auto txn = db.CreateWriteTxn();
+    for (int32_t i = 0; i < count; i++) {
+        auto vid1 = txn.AddVertex(
+            std::string("Person"), vp,
+            {FieldData::Int32(i), FieldData::String(std::to_string(i)),
+             FieldData::Int64(i)});
+        check.emplace_back(vid1, i);
+    }
+    txn.Commit();
+    FieldSpec fs("addr", FieldType::STRING, true);
+    size_t modified = 0;
+    UT_EXPECT_TRUE(db.AlterVertexLabelAddFields("Person", {fs}, {FieldData()}, &modified));
+    UT_EXPECT_EQ(modified, count);
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto viter = txn.GetVertexIterator(item.first);
+        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
+        UT_EXPECT_EQ(viter.GetField("int64").AsInt64(), item.second);
+        UT_EXPECT_TRUE(viter.GetField("addr").IsNull());
+    }
+    txn.Abort();
+    txn = db.CreateWriteTxn();
+    for (auto& item : check) {
+        auto viter = txn.GetVertexIterator(item.first);
+        viter.SetField("addr", FieldData::String(std::to_string(item.second)));
+    }
+    txn.Commit();
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto viter = txn.GetVertexIterator(item.first);
+        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
+        UT_EXPECT_EQ(viter.GetField("int64").AsInt64(), item.second);
+        UT_EXPECT_EQ(viter.GetField("addr").AsString(), std::to_string(item.second));
+    }
+    txn.Abort();
+}
+
+TEST_F(TestAlterDetachedLabel, vertex_delete_field) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo;
+    vo.primary_field = "id";
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
+                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                             {"str", FieldType::STRING, true},
+                                                             {"int64", FieldType::INT64, true}}),
+                                     vo));
+    std::vector<std::string> vp({"id", "str", "int64"});
+    std::vector<std::pair<int64_t, int32_t>> check;
+    int count = 10000;
+    auto txn = db.CreateWriteTxn();
+    for (int32_t i = 0; i < count; i++) {
+        auto vid1 = txn.AddVertex(
+            std::string("Person"), vp,
+            {FieldData::Int32(i), FieldData::String(std::to_string(i)),
+             FieldData::Int64(i)});
+        check.emplace_back(vid1, i);
+    }
+    txn.Commit();
+    size_t modified = 0;
+    UT_EXPECT_TRUE(db.AlterVertexLabelDelFields("Person", {"int64", "str"}, &modified));
+    UT_EXPECT_EQ(modified, count);
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto viter = txn.GetVertexIterator(item.first);
+        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_TRUE(viter.GetField("str").IsNull());
+        UT_EXPECT_TRUE(viter.GetField("int64").IsNull());
+    }
+    txn.Abort();
+}
+
+TEST_F(TestAlterDetachedLabel, vertex_mod_field) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo;
+    vo.primary_field = "id";
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
+                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                             {"str", FieldType::STRING, true},
+                                                             {"int64", FieldType::INT64, true}}),
+                                     vo));
+    std::vector<std::string> vp({"id", "str", "int64"});
+    std::vector<std::pair<int64_t, int32_t>> check;
+    int count = 10000;
+    auto txn = db.CreateWriteTxn();
+    for (int32_t i = 0; i < count; i++) {
+        auto vid1 = txn.AddVertex(
+            std::string("Person"), vp,
+            {FieldData::Int32(i), FieldData::String(std::to_string(i)),
+             FieldData::Int64(i)});
+        check.emplace_back(vid1, i);
+    }
+    txn.Commit();
+    size_t modified = 0;
+    std::vector<FieldSpec> mod {FieldSpec("int64", FieldType::INT32, true)};
+    UT_EXPECT_TRUE(db.AlterVertexLabelModFields("Person", mod, &modified));
+    UT_EXPECT_EQ(modified, count);
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto viter = txn.GetVertexIterator(item.first);
+        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
+        UT_EXPECT_EQ(viter.GetField("int64").AsInt32(), item.second);
+    }
+    txn.Abort();
+}


### PR DESCRIPTION
Optimize the process of altering vertex label in the detached model. Use the property table to speed up the data scan