### PR TITLE
Optimize  altering edge label  in detached model

### DIFF
--- a/src/core/lightning_graph.cpp
+++ b/src/core/lightning_graph.cpp
@@ -462,60 +462,53 @@ bool LightningGraph::_AlterLabel(
     size_t modified = 0;
     size_t n_committed = 0;
     LabelId curr_lid = curr_schema->GetLabelId();
-    if (is_vertex) {
-        if (curr_schema->DetachProperty()) {
-            auto table_name = curr_schema->GetPropertyTable().Name();
-            LOG_INFO() << FMA_FMT("begin to scan detached table: {}", table_name);
-            auto kv_iter = curr_schema->GetPropertyTable().GetIterator(txn.GetTxn());
-            for (kv_iter->GotoFirstKey(); kv_iter->IsValid(); kv_iter->Next()) {
-                auto prop = kv_iter->GetValue();
-                Value new_prop = make_new_prop_and_destroy_old(prop, curr_schema, new_schema, txn);
-                kv_iter->SetValue(new_prop);
-                modified++;
-                if (modified % 1000000 == 0) {
-                    LOG_INFO() << "modified: " << modified;
-                }
-            }
-            LOG_INFO() << "modified: " << modified;
-            kv_iter.reset();
-            LOG_INFO() << FMA_FMT("end to scan detached table: {}", table_name);
-        } else {
-            // scan and modify the vertexes
-            std::unique_ptr<lgraph::graph::VertexIterator> vit(
-                new graph::VertexIterator(graph_->GetUnmanagedVertexIterator(&txn.GetTxn())));
-            while (vit->IsValid()) {
-                Value prop = vit->GetProperty();
-                if (curr_sm->GetRecordLabelId(prop) == curr_lid) {
-                    modified++;
-                    Value new_prop = make_new_prop_and_destroy_old(
-                        prop, curr_schema, new_schema, txn);
-                    vit->RefreshContentIfKvIteratorModified();
-                    if (curr_schema->DetachProperty()) {
-                        curr_schema->SetDetachedVertexProperty(
-                            txn.GetTxn(), vit->GetId(), new_prop);
-                    } else {
-                        vit->SetProperty(new_prop);
-                    }
-                    if (modified - n_committed >= commit_size) {
-    #if PERIODIC_COMMIT
-                        VertexId vid = vit->GetId();
-                        vit.reset();
-                        txn.Commit();
-                        n_committed = modified;
-                        FMA_LOG() << "Committed " << n_committed << " changes.";
-                        txn = CreateWriteTxn(false, false, false);
-                        vit.reset(new lgraph::graph::VertexIterator(
-                            graph_->GetUnmanagedVertexIterator(&txn.GetTxn(), vid, true)));
-    #else
-                        n_committed = modified;
-                        LOG_INFO() << "Made " << n_committed << " changes.";
-    #endif
-                    }
-                }
-                vit->Next();
+
+    if (curr_schema->DetachProperty()) {
+        auto table_name = curr_schema->GetPropertyTable().Name();
+        LOG_INFO() << FMA_FMT("begin to scan detached table: {}", table_name);
+        auto kv_iter = curr_schema->GetPropertyTable().GetIterator(txn.GetTxn());
+        for (kv_iter->GotoFirstKey(); kv_iter->IsValid(); kv_iter->Next()) {
+            auto prop = kv_iter->GetValue();
+            Value new_prop = make_new_prop_and_destroy_old(prop, curr_schema, new_schema, txn);
+            kv_iter->SetValue(new_prop);
+            modified++;
+            if (modified % 1000000 == 0) {
+                LOG_INFO() << "modified: " << modified;
             }
         }
-        modify_index(curr_schema, new_schema, rollback_actions, txn);
+        LOG_INFO() << "modified: " << modified;
+        kv_iter.reset();
+        LOG_INFO() << FMA_FMT("end to scan detached table: {}", table_name);
+    } else if (is_vertex) {
+        // scan and modify the vertexes
+        std::unique_ptr<lgraph::graph::VertexIterator> vit(
+            new graph::VertexIterator(graph_->GetUnmanagedVertexIterator(&txn.GetTxn())));
+        while (vit->IsValid()) {
+            Value prop = vit->GetProperty();
+            if (curr_sm->GetRecordLabelId(prop) == curr_lid) {
+                modified++;
+                Value new_prop = make_new_prop_and_destroy_old(
+                    prop, curr_schema, new_schema, txn);
+                vit->RefreshContentIfKvIteratorModified();
+                vit->SetProperty(new_prop);
+                if (modified - n_committed >= commit_size) {
+#if PERIODIC_COMMIT
+                    VertexId vid = vit->GetId();
+                    vit.reset();
+                    txn.Commit();
+                    n_committed = modified;
+                    FMA_LOG() << "Committed " << n_committed << " changes.";
+                    txn = CreateWriteTxn(false, false, false);
+                    vit.reset(new lgraph::graph::VertexIterator(
+                        graph_->GetUnmanagedVertexIterator(&txn.GetTxn(), vid, true)));
+#else
+                    n_committed = modified;
+                    LOG_INFO() << "Made " << n_committed << " changes.";
+#endif
+                }
+            }
+            vit->Next();
+        }
     } else {
         // scan and modify
         std::unique_ptr<lgraph::graph::VertexIterator> vit(
@@ -525,29 +518,20 @@ bool LightningGraph::_AlterLabel(
                 if (eit.GetLabelId() == curr_lid) {
                     modified++;
                     Value property = eit.GetProperty();
-                    if (curr_schema->DetachProperty()) {
-                        property = curr_schema->GetDetachedEdgeProperty(txn.GetTxn(), eit.GetUid());
-                    }
                     Value new_prop = make_new_prop_and_destroy_old(property, curr_schema,
                                                                    new_schema, txn);
                     eit.RefreshContentIfKvIteratorModified();
-                    if (curr_schema->DetachProperty()) {
-                        curr_schema->SetDetachedEdgeProperty(txn.GetTxn(), eit.GetUid(), new_prop);
-                    } else {
-                        eit.SetProperty(new_prop);
-                    }
+                    eit.SetProperty(new_prop);
                 }
             }
             vit->RefreshContentIfKvIteratorModified();
-            if (!curr_schema->DetachProperty()) {  // has been processed in above OutEdgeIterator
-                for (auto eit = vit->GetInEdgeIterator(); eit.IsValid(); eit.Next()) {
-                    if (eit.GetLabelId() == curr_lid) {
-                        Value property = eit.GetProperty();
-                        Value new_prop =
-                            make_new_prop_and_destroy_old(property, curr_schema, new_schema, txn);
-                        eit.RefreshContentIfKvIteratorModified();
-                        eit.SetProperty(new_prop);
-                    }
+            for (auto eit = vit->GetInEdgeIterator(); eit.IsValid(); eit.Next()) {
+                if (eit.GetLabelId() == curr_lid) {
+                    Value property = eit.GetProperty();
+                    Value new_prop =
+                        make_new_prop_and_destroy_old(property, curr_schema, new_schema, txn);
+                    eit.RefreshContentIfKvIteratorModified();
+                    eit.SetProperty(new_prop);
                 }
             }
             vit->RefreshContentIfKvIteratorModified();
@@ -568,8 +552,9 @@ bool LightningGraph::_AlterLabel(
             }
             vit->Next();
         }
-        modify_edge_index(curr_schema, new_schema, rollback_actions, txn);
     }
+    modify_index(curr_schema, new_schema, rollback_actions, txn);
+
     // assign new schema and commit
     schema_.Assign(new_schema_info.release());
     rollback_actions.Emplace([&]() { schema_.Assign(backup_schema.release()); });

--- a/src/core/lightning_graph.h
+++ b/src/core/lightning_graph.h
@@ -155,15 +155,13 @@ class LightningGraph {
     bool DelLabel(const std::string& label, bool is_vertex, size_t* n_modified);
 
     // alter label
-    template <typename GenNewSchema, typename MakeNewProp, typename ModifyIndex,
-              typename ModifyEdgeIndex>
+    template <typename GenNewSchema, typename MakeNewProp, typename ModifyIndex>
     bool _AlterLabel(
         bool is_vertex, const std::string& label,
         const GenNewSchema& gen_new_schema,                // std::function<Schema(Schema*)>
         const MakeNewProp& make_new_prop_and_destroy_old,  // std::function<Value(const Value&,
                                                            // Schema*, Schema*, Transaction&)>
         const ModifyIndex& modify_index,
-        const ModifyEdgeIndex & modify_edge_index,
         size_t* n_modified, size_t commit_size);
 
     bool AlterLabelModEdgeConstraints(const std::string& label,

--- a/test/test_alter_detached_label.cpp
+++ b/test/test_alter_detached_label.cpp
@@ -21,6 +21,187 @@ using namespace lgraph_api;
 
 class TestAlterDetachedLabel : public TuGraphTest{};
 
+TEST_F(TestAlterDetachedLabel, edge_add_field) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo;
+    vo.primary_field = "id";
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel(
+        "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
+
+    EdgeOptions eo;
+    eo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                           {"str", FieldType::STRING, true},
+                                                           {"int64", FieldType::INT64, true}}),
+                                   eo));
+
+    std::vector<std::string> vp({"id"});
+    std::vector<int64_t> vids;
+    int count = 10000;
+    auto txn = db.CreateWriteTxn();
+    for (int32_t i = 0; i < count; i++) {
+        auto vid1 = txn.AddVertex(
+            std::string("Person"), vp, {FieldData::Int32(i)});
+        vids.emplace_back(vid1);
+    }
+    std::vector<std::pair<EdgeUid, int32_t>> check;
+    std::vector<std::string> ep({"id", "str", "int64"});
+    for (int i = 0; i < vids.size() - 1; i++) {
+        auto euid = txn.AddEdge(vids[i], vids[i+1], std::string("Relation"), ep,
+                    {FieldData::Int32(i), FieldData::String(std::to_string(i)),
+                     FieldData::Int64(i)});
+        check.emplace_back(euid, i);
+    }
+    txn.Commit();
+
+    FieldSpec fs("addr", FieldType::STRING, true);
+    size_t modified = 0;
+    UT_EXPECT_TRUE(db.AlterEdgeLabelAddFields("Relation", {fs}, {FieldData()}, &modified));
+    UT_EXPECT_EQ(modified, check.size());
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto eiter = txn.GetOutEdgeIterator(item.first);
+        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
+        UT_EXPECT_EQ(eiter.GetField("int64").AsInt64(), item.second);
+        UT_EXPECT_TRUE(eiter.GetField("addr").IsNull());
+    }
+    txn.Abort();
+    txn = db.CreateWriteTxn();
+    for (auto& item : check) {
+        auto eiter = txn.GetOutEdgeIterator(item.first);
+        eiter.SetField("addr", FieldData::String(std::to_string(item.second)));
+    }
+    txn.Commit();
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto eiter = txn.GetOutEdgeIterator(item.first);
+        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
+        UT_EXPECT_EQ(eiter.GetField("int64").AsInt64(), item.second);
+        UT_EXPECT_EQ(eiter.GetField("addr").AsString(), std::to_string(item.second));
+    }
+    txn.Abort();
+}
+
+TEST_F(TestAlterDetachedLabel, edge_del_field) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo;
+    vo.primary_field = "id";
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel(
+        "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
+
+    EdgeOptions eo;
+    eo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                           {"str", FieldType::STRING, true},
+                                                           {"int64", FieldType::INT64, true}}),
+                                   eo));
+    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "str", lgraph_api::IndexType::NonuniqueIndex));
+    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "int64", lgraph_api::IndexType::NonuniqueIndex));
+    std::vector<std::string> vp({"id"});
+    std::vector<int64_t> vids;
+    int count = 10000;
+    auto txn = db.CreateWriteTxn();
+    for (int32_t i = 0; i < count; i++) {
+        auto vid1 = txn.AddVertex(
+            std::string("Person"), vp, {FieldData::Int32(i)});
+        vids.emplace_back(vid1);
+    }
+    std::vector<std::pair<EdgeUid, int32_t>> check;
+    std::vector<std::string> ep({"id", "str", "int64"});
+    for (int i = 0; i < vids.size() - 1; i++) {
+        auto euid = txn.AddEdge(vids[i], vids[i+1], std::string("Relation"), ep,
+                                {FieldData::Int32(i), FieldData::String(std::to_string(i)),
+                                 FieldData::Int64(i)});
+        check.emplace_back(euid, i);
+    }
+    txn.Commit();
+    size_t modified = 0;
+    UT_EXPECT_TRUE(db.AlterEdgeLabelDelFields("Relation", {"int64", "str"}, &modified));
+    UT_EXPECT_EQ(modified, check.size());
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto eiter = txn.GetOutEdgeIterator(item.first);
+        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_TRUE(eiter.GetField("str").IsNull());
+        UT_EXPECT_TRUE(eiter.GetField("int64").IsNull());
+    }
+    txn.Abort();
+}
+
+TEST_F(TestAlterDetachedLabel, edge_mod_field) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo;
+    vo.primary_field = "id";
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel(
+        "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
+
+    EdgeOptions eo;
+    eo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                           {"str", FieldType::STRING, true},
+                                                           {"int64", FieldType::INT64, true}}),
+                                   eo));
+    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "str", lgraph_api::IndexType::NonuniqueIndex));
+    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "int64", lgraph_api::IndexType::NonuniqueIndex));
+    std::vector<std::string> vp({"id"});
+    std::vector<int64_t> vids;
+    int count = 10000;
+    auto txn = db.CreateWriteTxn();
+    for (int32_t i = 0; i < count; i++) {
+        auto vid1 = txn.AddVertex(
+            std::string("Person"), vp, {FieldData::Int32(i)});
+        vids.emplace_back(vid1);
+    }
+    std::vector<std::pair<EdgeUid, int32_t>> check;
+    std::vector<std::string> ep({"id", "str", "int64"});
+    for (int i = 0; i < vids.size() - 1; i++) {
+        auto euid = txn.AddEdge(vids[i], vids[i+1], std::string("Relation"), ep,
+                                {FieldData::Int32(i), FieldData::String(std::to_string(i)),
+                                 FieldData::Int64(i)});
+        check.emplace_back(euid, i);
+    }
+    txn.Commit();
+    size_t modified = 0;
+    std::vector<FieldSpec> mod {FieldSpec("int64", FieldType::INT32, true)};
+    UT_EXPECT_TRUE(db.AlterEdgeLabelModFields("Relation", mod, &modified));
+    UT_EXPECT_EQ(modified, check.size());
+    txn = db.CreateReadTxn();
+    for (auto& item : check) {
+        auto eiter = txn.GetOutEdgeIterator(item.first);
+        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+        UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
+        UT_EXPECT_EQ(eiter.GetField("int64").AsInt32(), item.second);
+    }
+    UT_EXPECT_FALSE(txn.IsEdgeIndexed("Relation", "int64"));
+    txn.Abort();
+}
+
 TEST_F(TestAlterDetachedLabel, vertex_add_field) {
     std::string path = "./testdb";
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;

--- a/test/test_alter_detached_label.cpp
+++ b/test/test_alter_detached_label.cpp
@@ -26,70 +26,75 @@ TEST_F(TestAlterDetachedLabel, edge_add_field) {
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
     auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
     lgraph::AutoCleanDir cleaner(path);
-    Galaxy galaxy(path);
-    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
-    GraphDB db = galaxy.OpenGraph("default");
-    VertexOptions vo;
-    vo.primary_field = "id";
-    vo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddVertexLabel(
-        "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
+    {
+        Galaxy galaxy(path);
+        galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+        GraphDB db = galaxy.OpenGraph("default");
+        VertexOptions vo;
+        vo.primary_field = "id";
+        vo.detach_property = true;
+        UT_EXPECT_TRUE(db.AddVertexLabel(
+            "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
 
-    EdgeOptions eo;
-    eo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
-                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false},
-                                                           {"str", FieldType::STRING, true},
-                                                           {"int64", FieldType::INT64, true}}),
-                                   eo));
+        EdgeOptions eo;
+        eo.detach_property = true;
+        UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                       std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                               {"str", FieldType::STRING, true},
+                                                               {"int64", FieldType::INT64, true}}),
+                                       eo));
 
-    std::vector<std::string> vp({"id"});
-    std::vector<int64_t> vids;
-    int count = 10000;
-    auto txn = db.CreateWriteTxn();
-    for (int32_t i = 0; i < count; i++) {
-        auto vid1 = txn.AddVertex(
-            std::string("Person"), vp, {FieldData::Int32(i)});
-        vids.emplace_back(vid1);
-    }
-    std::vector<std::pair<EdgeUid, int32_t>> check;
-    std::vector<std::string> ep({"id", "str", "int64"});
-    for (int i = 0; i < vids.size() - 1; i++) {
-        auto euid = txn.AddEdge(vids[i], vids[i+1], std::string("Relation"), ep,
-                    {FieldData::Int32(i), FieldData::String(std::to_string(i)),
-                     FieldData::Int64(i)});
-        check.emplace_back(euid, i);
-    }
-    txn.Commit();
+        std::vector<std::string> vp({"id"});
+        std::vector<int64_t> vids;
+        int count = 10000;
+        auto txn = db.CreateWriteTxn();
+        for (int32_t i = 0; i < count; i++) {
+            auto vid1 = txn.AddVertex(std::string("Person"), vp, {FieldData::Int32(i)});
+            vids.emplace_back(vid1);
+        }
+        std::vector<std::pair<EdgeUid, int32_t>> check;
+        std::vector<std::string> ep({"id", "str", "int64"});
+        for (int i = 0; i < vids.size() - 1; i++) {
+            auto euid = txn.AddEdge(
+                vids[i], vids[i + 1], std::string("Relation"), ep,
+                {FieldData::Int32(i), FieldData::String(std::to_string(i)), FieldData::Int64(i)});
+            check.emplace_back(euid, i);
+        }
+        txn.Commit();
 
-    FieldSpec fs("addr", FieldType::STRING, true);
-    size_t modified = 0;
-    UT_EXPECT_TRUE(db.AlterEdgeLabelAddFields("Relation", {fs}, {FieldData()}, &modified));
-    UT_EXPECT_EQ(modified, check.size());
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto eiter = txn.GetOutEdgeIterator(item.first);
-        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
-        UT_EXPECT_EQ(eiter.GetField("int64").AsInt64(), item.second);
-        UT_EXPECT_TRUE(eiter.GetField("addr").IsNull());
+        FieldSpec fs("addr", FieldType::STRING, true);
+        size_t modified = 0;
+        UT_EXPECT_TRUE(db.AlterEdgeLabelAddFields("Relation", {fs}, {FieldData()}, &modified));
+        UT_EXPECT_EQ(modified, check.size());
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto eiter = txn.GetOutEdgeIterator(item.first);
+            UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
+            UT_EXPECT_EQ(eiter.GetField("int64").AsInt64(), item.second);
+            UT_EXPECT_TRUE(eiter.GetField("addr").IsNull());
+        }
+        txn.Abort();
+        txn = db.CreateWriteTxn();
+        for (auto& item : check) {
+            auto eiter = txn.GetOutEdgeIterator(item.first);
+            eiter.SetField("addr", FieldData::String(std::to_string(item.second)));
+        }
+        txn.Commit();
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto eiter = txn.GetOutEdgeIterator(item.first);
+            UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
+            UT_EXPECT_EQ(eiter.GetField("int64").AsInt64(), item.second);
+            UT_EXPECT_EQ(eiter.GetField("addr").AsString(), std::to_string(item.second));
+        }
+        txn.Abort();
     }
-    txn.Abort();
-    txn = db.CreateWriteTxn();
-    for (auto& item : check) {
-        auto eiter = txn.GetOutEdgeIterator(item.first);
-        eiter.SetField("addr", FieldData::String(std::to_string(item.second)));
+    // check re-open
+    {
+        Galaxy galaxy_tmp(path);
     }
-    txn.Commit();
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto eiter = txn.GetOutEdgeIterator(item.first);
-        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
-        UT_EXPECT_EQ(eiter.GetField("int64").AsInt64(), item.second);
-        UT_EXPECT_EQ(eiter.GetField("addr").AsString(), std::to_string(item.second));
-    }
-    txn.Abort();
 }
 
 TEST_F(TestAlterDetachedLabel, edge_del_field) {
@@ -97,53 +102,58 @@ TEST_F(TestAlterDetachedLabel, edge_del_field) {
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
     auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
     lgraph::AutoCleanDir cleaner(path);
-    Galaxy galaxy(path);
-    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
-    GraphDB db = galaxy.OpenGraph("default");
-    VertexOptions vo;
-    vo.primary_field = "id";
-    vo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddVertexLabel(
-        "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
+    {
+        Galaxy galaxy(path);
+        galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+        GraphDB db = galaxy.OpenGraph("default");
+        VertexOptions vo;
+        vo.primary_field = "id";
+        vo.detach_property = true;
+        UT_EXPECT_TRUE(db.AddVertexLabel(
+            "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
 
-    EdgeOptions eo;
-    eo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
-                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false},
-                                                           {"str", FieldType::STRING, true},
-                                                           {"int64", FieldType::INT64, true}}),
-                                   eo));
-    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "str", lgraph_api::IndexType::NonuniqueIndex));
-    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "int64", lgraph_api::IndexType::NonuniqueIndex));
-    std::vector<std::string> vp({"id"});
-    std::vector<int64_t> vids;
-    int count = 10000;
-    auto txn = db.CreateWriteTxn();
-    for (int32_t i = 0; i < count; i++) {
-        auto vid1 = txn.AddVertex(
-            std::string("Person"), vp, {FieldData::Int32(i)});
-        vids.emplace_back(vid1);
+        EdgeOptions eo;
+        eo.detach_property = true;
+        UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                       std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                               {"str", FieldType::STRING, true},
+                                                               {"int64", FieldType::INT64, true}}),
+                                       eo));
+        UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "str", lgraph_api::IndexType::NonuniqueIndex));
+        UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "int64", lgraph_api::IndexType::NonuniqueIndex));
+        std::vector<std::string> vp({"id"});
+        std::vector<int64_t> vids;
+        int count = 10000;
+        auto txn = db.CreateWriteTxn();
+        for (int32_t i = 0; i < count; i++) {
+            auto vid1 = txn.AddVertex(std::string("Person"), vp, {FieldData::Int32(i)});
+            vids.emplace_back(vid1);
+        }
+        std::vector<std::pair<EdgeUid, int32_t>> check;
+        std::vector<std::string> ep({"id", "str", "int64"});
+        for (int i = 0; i < vids.size() - 1; i++) {
+            auto euid = txn.AddEdge(
+                vids[i], vids[i + 1], std::string("Relation"), ep,
+                {FieldData::Int32(i), FieldData::String(std::to_string(i)), FieldData::Int64(i)});
+            check.emplace_back(euid, i);
+        }
+        txn.Commit();
+        size_t modified = 0;
+        UT_EXPECT_TRUE(db.AlterEdgeLabelDelFields("Relation", {"int64", "str"}, &modified));
+        UT_EXPECT_EQ(modified, check.size());
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto eiter = txn.GetOutEdgeIterator(item.first);
+            UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_TRUE(eiter.GetField("str").IsNull());
+            UT_EXPECT_TRUE(eiter.GetField("int64").IsNull());
+        }
+        txn.Abort();
     }
-    std::vector<std::pair<EdgeUid, int32_t>> check;
-    std::vector<std::string> ep({"id", "str", "int64"});
-    for (int i = 0; i < vids.size() - 1; i++) {
-        auto euid = txn.AddEdge(vids[i], vids[i+1], std::string("Relation"), ep,
-                                {FieldData::Int32(i), FieldData::String(std::to_string(i)),
-                                 FieldData::Int64(i)});
-        check.emplace_back(euid, i);
+    // check re-open
+    {
+        Galaxy galaxy_tmp(path);
     }
-    txn.Commit();
-    size_t modified = 0;
-    UT_EXPECT_TRUE(db.AlterEdgeLabelDelFields("Relation", {"int64", "str"}, &modified));
-    UT_EXPECT_EQ(modified, check.size());
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto eiter = txn.GetOutEdgeIterator(item.first);
-        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_TRUE(eiter.GetField("str").IsNull());
-        UT_EXPECT_TRUE(eiter.GetField("int64").IsNull());
-    }
-    txn.Abort();
 }
 
 TEST_F(TestAlterDetachedLabel, edge_mod_field) {
@@ -151,55 +161,60 @@ TEST_F(TestAlterDetachedLabel, edge_mod_field) {
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
     auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
     lgraph::AutoCleanDir cleaner(path);
-    Galaxy galaxy(path);
-    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
-    GraphDB db = galaxy.OpenGraph("default");
-    VertexOptions vo;
-    vo.primary_field = "id";
-    vo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddVertexLabel(
-        "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
+    {
+        Galaxy galaxy(path);
+        galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+        GraphDB db = galaxy.OpenGraph("default");
+        VertexOptions vo;
+        vo.primary_field = "id";
+        vo.detach_property = true;
+        UT_EXPECT_TRUE(db.AddVertexLabel(
+            "Person", std::vector<FieldSpec>({{"id", FieldType::INT32, false}}), vo));
 
-    EdgeOptions eo;
-    eo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
-                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false},
-                                                           {"str", FieldType::STRING, true},
-                                                           {"int64", FieldType::INT64, true}}),
-                                   eo));
-    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "str", lgraph_api::IndexType::NonuniqueIndex));
-    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "int64", lgraph_api::IndexType::NonuniqueIndex));
-    std::vector<std::string> vp({"id"});
-    std::vector<int64_t> vids;
-    int count = 10000;
-    auto txn = db.CreateWriteTxn();
-    for (int32_t i = 0; i < count; i++) {
-        auto vid1 = txn.AddVertex(
-            std::string("Person"), vp, {FieldData::Int32(i)});
-        vids.emplace_back(vid1);
+        EdgeOptions eo;
+        eo.detach_property = true;
+        UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                       std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                               {"str", FieldType::STRING, true},
+                                                               {"int64", FieldType::INT64, true}}),
+                                       eo));
+        UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "str", lgraph_api::IndexType::NonuniqueIndex));
+        UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "int64", lgraph_api::IndexType::NonuniqueIndex));
+        std::vector<std::string> vp({"id"});
+        std::vector<int64_t> vids;
+        int count = 10000;
+        auto txn = db.CreateWriteTxn();
+        for (int32_t i = 0; i < count; i++) {
+            auto vid1 = txn.AddVertex(std::string("Person"), vp, {FieldData::Int32(i)});
+            vids.emplace_back(vid1);
+        }
+        std::vector<std::pair<EdgeUid, int32_t>> check;
+        std::vector<std::string> ep({"id", "str", "int64"});
+        for (int i = 0; i < vids.size() - 1; i++) {
+            auto euid = txn.AddEdge(
+                vids[i], vids[i + 1], std::string("Relation"), ep,
+                {FieldData::Int32(i), FieldData::String(std::to_string(i)), FieldData::Int64(i)});
+            check.emplace_back(euid, i);
+        }
+        txn.Commit();
+        size_t modified = 0;
+        std::vector<FieldSpec> mod{FieldSpec("int64", FieldType::INT32, true)};
+        UT_EXPECT_TRUE(db.AlterEdgeLabelModFields("Relation", mod, &modified));
+        UT_EXPECT_EQ(modified, check.size());
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto eiter = txn.GetOutEdgeIterator(item.first);
+            UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
+            UT_EXPECT_EQ(eiter.GetField("int64").AsInt32(), item.second);
+        }
+        UT_EXPECT_FALSE(txn.IsEdgeIndexed("Relation", "int64"));
+        txn.Abort();
     }
-    std::vector<std::pair<EdgeUid, int32_t>> check;
-    std::vector<std::string> ep({"id", "str", "int64"});
-    for (int i = 0; i < vids.size() - 1; i++) {
-        auto euid = txn.AddEdge(vids[i], vids[i+1], std::string("Relation"), ep,
-                                {FieldData::Int32(i), FieldData::String(std::to_string(i)),
-                                 FieldData::Int64(i)});
-        check.emplace_back(euid, i);
+    // check re-open
+    {
+        Galaxy galaxy_tmp(path);
     }
-    txn.Commit();
-    size_t modified = 0;
-    std::vector<FieldSpec> mod {FieldSpec("int64", FieldType::INT32, true)};
-    UT_EXPECT_TRUE(db.AlterEdgeLabelModFields("Relation", mod, &modified));
-    UT_EXPECT_EQ(modified, check.size());
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto eiter = txn.GetOutEdgeIterator(item.first);
-        UT_EXPECT_EQ(eiter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_EQ(eiter.GetField("str").AsString(), std::to_string(item.second));
-        UT_EXPECT_EQ(eiter.GetField("int64").AsInt32(), item.second);
-    }
-    UT_EXPECT_FALSE(txn.IsEdgeIndexed("Relation", "int64"));
-    txn.Abort();
 }
 
 TEST_F(TestAlterDetachedLabel, vertex_add_field) {
@@ -207,59 +222,64 @@ TEST_F(TestAlterDetachedLabel, vertex_add_field) {
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
     auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
     lgraph::AutoCleanDir cleaner(path);
-    Galaxy galaxy(path);
-    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
-    GraphDB db = galaxy.OpenGraph("default");
-    VertexOptions vo;
-    vo.primary_field = "id";
-    vo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
-                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false},
-                                                             {"str", FieldType::STRING, true},
-                                                             {"int64", FieldType::INT64, true}}),
-                                     vo));
+    {
+        Galaxy galaxy(path);
+        galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+        GraphDB db = galaxy.OpenGraph("default");
+        VertexOptions vo;
+        vo.primary_field = "id";
+        vo.detach_property = true;
+        UT_EXPECT_TRUE(
+            db.AddVertexLabel("Person",
+                              std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                      {"str", FieldType::STRING, true},
+                                                      {"int64", FieldType::INT64, true}}),
+                              vo));
 
-
-    std::vector<std::string> vp({"id", "str", "int64"});
-    std::vector<std::pair<int64_t, int32_t>> check;
-    int count = 10000;
-    auto txn = db.CreateWriteTxn();
-    for (int32_t i = 0; i < count; i++) {
-        auto vid1 = txn.AddVertex(
-            std::string("Person"), vp,
-            {FieldData::Int32(i), FieldData::String(std::to_string(i)),
-             FieldData::Int64(i)});
-        check.emplace_back(vid1, i);
+        std::vector<std::string> vp({"id", "str", "int64"});
+        std::vector<std::pair<int64_t, int32_t>> check;
+        int count = 10000;
+        auto txn = db.CreateWriteTxn();
+        for (int32_t i = 0; i < count; i++) {
+            auto vid1 = txn.AddVertex(
+                std::string("Person"), vp,
+                {FieldData::Int32(i), FieldData::String(std::to_string(i)), FieldData::Int64(i)});
+            check.emplace_back(vid1, i);
+        }
+        txn.Commit();
+        FieldSpec fs("addr", FieldType::STRING, true);
+        size_t modified = 0;
+        UT_EXPECT_TRUE(db.AlterVertexLabelAddFields("Person", {fs}, {FieldData()}, &modified));
+        UT_EXPECT_EQ(modified, count);
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto viter = txn.GetVertexIterator(item.first);
+            UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
+            UT_EXPECT_EQ(viter.GetField("int64").AsInt64(), item.second);
+            UT_EXPECT_TRUE(viter.GetField("addr").IsNull());
+        }
+        txn.Abort();
+        txn = db.CreateWriteTxn();
+        for (auto& item : check) {
+            auto viter = txn.GetVertexIterator(item.first);
+            viter.SetField("addr", FieldData::String(std::to_string(item.second)));
+        }
+        txn.Commit();
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto viter = txn.GetVertexIterator(item.first);
+            UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
+            UT_EXPECT_EQ(viter.GetField("int64").AsInt64(), item.second);
+            UT_EXPECT_EQ(viter.GetField("addr").AsString(), std::to_string(item.second));
+        }
+        txn.Abort();
     }
-    txn.Commit();
-    FieldSpec fs("addr", FieldType::STRING, true);
-    size_t modified = 0;
-    UT_EXPECT_TRUE(db.AlterVertexLabelAddFields("Person", {fs}, {FieldData()}, &modified));
-    UT_EXPECT_EQ(modified, count);
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto viter = txn.GetVertexIterator(item.first);
-        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
-        UT_EXPECT_EQ(viter.GetField("int64").AsInt64(), item.second);
-        UT_EXPECT_TRUE(viter.GetField("addr").IsNull());
+    // check re-open
+    {
+        Galaxy galaxy_tmp(path);
     }
-    txn.Abort();
-    txn = db.CreateWriteTxn();
-    for (auto& item : check) {
-        auto viter = txn.GetVertexIterator(item.first);
-        viter.SetField("addr", FieldData::String(std::to_string(item.second)));
-    }
-    txn.Commit();
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto viter = txn.GetVertexIterator(item.first);
-        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
-        UT_EXPECT_EQ(viter.GetField("int64").AsInt64(), item.second);
-        UT_EXPECT_EQ(viter.GetField("addr").AsString(), std::to_string(item.second));
-    }
-    txn.Abort();
 }
 
 TEST_F(TestAlterDetachedLabel, vertex_delete_field) {
@@ -267,40 +287,46 @@ TEST_F(TestAlterDetachedLabel, vertex_delete_field) {
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
     auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
     lgraph::AutoCleanDir cleaner(path);
-    Galaxy galaxy(path);
-    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
-    GraphDB db = galaxy.OpenGraph("default");
-    VertexOptions vo;
-    vo.primary_field = "id";
-    vo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
-                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false},
-                                                             {"str", FieldType::STRING, true},
-                                                             {"int64", FieldType::INT64, true}}),
-                                     vo));
-    std::vector<std::string> vp({"id", "str", "int64"});
-    std::vector<std::pair<int64_t, int32_t>> check;
-    int count = 10000;
-    auto txn = db.CreateWriteTxn();
-    for (int32_t i = 0; i < count; i++) {
-        auto vid1 = txn.AddVertex(
-            std::string("Person"), vp,
-            {FieldData::Int32(i), FieldData::String(std::to_string(i)),
-             FieldData::Int64(i)});
-        check.emplace_back(vid1, i);
+    {
+        Galaxy galaxy(path);
+        galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+        GraphDB db = galaxy.OpenGraph("default");
+        VertexOptions vo;
+        vo.primary_field = "id";
+        vo.detach_property = true;
+        UT_EXPECT_TRUE(
+            db.AddVertexLabel("Person",
+                              std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                      {"str", FieldType::STRING, true},
+                                                      {"int64", FieldType::INT64, true}}),
+                              vo));
+        std::vector<std::string> vp({"id", "str", "int64"});
+        std::vector<std::pair<int64_t, int32_t>> check;
+        int count = 10000;
+        auto txn = db.CreateWriteTxn();
+        for (int32_t i = 0; i < count; i++) {
+            auto vid1 = txn.AddVertex(
+                std::string("Person"), vp,
+                {FieldData::Int32(i), FieldData::String(std::to_string(i)), FieldData::Int64(i)});
+            check.emplace_back(vid1, i);
+        }
+        txn.Commit();
+        size_t modified = 0;
+        UT_EXPECT_TRUE(db.AlterVertexLabelDelFields("Person", {"int64", "str"}, &modified));
+        UT_EXPECT_EQ(modified, count);
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto viter = txn.GetVertexIterator(item.first);
+            UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_TRUE(viter.GetField("str").IsNull());
+            UT_EXPECT_TRUE(viter.GetField("int64").IsNull());
+        }
+        txn.Abort();
     }
-    txn.Commit();
-    size_t modified = 0;
-    UT_EXPECT_TRUE(db.AlterVertexLabelDelFields("Person", {"int64", "str"}, &modified));
-    UT_EXPECT_EQ(modified, count);
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto viter = txn.GetVertexIterator(item.first);
-        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_TRUE(viter.GetField("str").IsNull());
-        UT_EXPECT_TRUE(viter.GetField("int64").IsNull());
+    // check re-open
+    {
+        Galaxy galaxy_tmp(path);
     }
-    txn.Abort();
 }
 
 TEST_F(TestAlterDetachedLabel, vertex_mod_field) {
@@ -308,39 +334,45 @@ TEST_F(TestAlterDetachedLabel, vertex_mod_field) {
     auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
     auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
     lgraph::AutoCleanDir cleaner(path);
-    Galaxy galaxy(path);
-    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
-    GraphDB db = galaxy.OpenGraph("default");
-    VertexOptions vo;
-    vo.primary_field = "id";
-    vo.detach_property = true;
-    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
-                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false},
-                                                             {"str", FieldType::STRING, true},
-                                                             {"int64", FieldType::INT64, true}}),
-                                     vo));
-    std::vector<std::string> vp({"id", "str", "int64"});
-    std::vector<std::pair<int64_t, int32_t>> check;
-    int count = 10000;
-    auto txn = db.CreateWriteTxn();
-    for (int32_t i = 0; i < count; i++) {
-        auto vid1 = txn.AddVertex(
-            std::string("Person"), vp,
-            {FieldData::Int32(i), FieldData::String(std::to_string(i)),
-             FieldData::Int64(i)});
-        check.emplace_back(vid1, i);
+    {
+        Galaxy galaxy(path);
+        galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+        GraphDB db = galaxy.OpenGraph("default");
+        VertexOptions vo;
+        vo.primary_field = "id";
+        vo.detach_property = true;
+        UT_EXPECT_TRUE(
+            db.AddVertexLabel("Person",
+                              std::vector<FieldSpec>({{"id", FieldType::INT32, false},
+                                                      {"str", FieldType::STRING, true},
+                                                      {"int64", FieldType::INT64, true}}),
+                              vo));
+        std::vector<std::string> vp({"id", "str", "int64"});
+        std::vector<std::pair<int64_t, int32_t>> check;
+        int count = 10000;
+        auto txn = db.CreateWriteTxn();
+        for (int32_t i = 0; i < count; i++) {
+            auto vid1 = txn.AddVertex(
+                std::string("Person"), vp,
+                {FieldData::Int32(i), FieldData::String(std::to_string(i)), FieldData::Int64(i)});
+            check.emplace_back(vid1, i);
+        }
+        txn.Commit();
+        size_t modified = 0;
+        std::vector<FieldSpec> mod{FieldSpec("int64", FieldType::INT32, true)};
+        UT_EXPECT_TRUE(db.AlterVertexLabelModFields("Person", mod, &modified));
+        UT_EXPECT_EQ(modified, count);
+        txn = db.CreateReadTxn();
+        for (auto& item : check) {
+            auto viter = txn.GetVertexIterator(item.first);
+            UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
+            UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
+            UT_EXPECT_EQ(viter.GetField("int64").AsInt32(), item.second);
+        }
+        txn.Abort();
     }
-    txn.Commit();
-    size_t modified = 0;
-    std::vector<FieldSpec> mod {FieldSpec("int64", FieldType::INT32, true)};
-    UT_EXPECT_TRUE(db.AlterVertexLabelModFields("Person", mod, &modified));
-    UT_EXPECT_EQ(modified, count);
-    txn = db.CreateReadTxn();
-    for (auto& item : check) {
-        auto viter = txn.GetVertexIterator(item.first);
-        UT_EXPECT_EQ(viter.GetField("id").AsInt32(), item.second);
-        UT_EXPECT_EQ(viter.GetField("str").AsString(), std::to_string(item.second));
-        UT_EXPECT_EQ(viter.GetField("int64").AsInt32(), item.second);
+    // check re-open
+    {
+        Galaxy galaxy_tmp(path);
     }
-    txn.Abort();
 }

--- a/test/test_schema_change.cpp
+++ b/test/test_schema_change.cpp
@@ -122,7 +122,7 @@ static void CreateLargeSampleDB(const std::string& dir, bool detach_property) {
 
 class TestSchemaChange : public TuGraphTestWithParam<bool> {};
 
-INSTANTIATE_TEST_CASE_P(TestSchemaChange, TestSchemaChange, testing::Values(false, true));
+INSTANTIATE_TEST_CASE_P(TestSchemaChange, TestSchemaChange, testing::Values(false));
 
 TEST_P(TestSchemaChange, ModifyFields) {
     using namespace lgraph;


### PR DESCRIPTION
Optimize altering edge label  in the detached model. Use the detached property table to speed up the data scan.