### PR TITLE
Fix bug about deleting vertex in detached model

### DIFF
--- a/include/lgraph/lgraph_txn.h
+++ b/include/lgraph/lgraph_txn.h
@@ -675,7 +675,6 @@ class Transaction {
      *          second is label name, third is number.
      */
     std::vector<std::tuple<bool, std::string, int64_t>> CountDetail();
-
 };
 
 }  // namespace lgraph_api

--- a/include/lgraph/lgraph_txn.h
+++ b/include/lgraph/lgraph_txn.h
@@ -675,6 +675,7 @@ class Transaction {
      *          second is label name, third is number.
      */
     std::vector<std::tuple<bool, std::string, int64_t>> CountDetail();
+
 };
 
 }  // namespace lgraph_api

--- a/src/core/lightning_graph.cpp
+++ b/src/core/lightning_graph.cpp
@@ -1939,7 +1939,7 @@ bool LightningGraph::BlockingAddIndex(const std::string& label, const std::strin
             txn.Commit();
             schema_.Assign(new_schema.release());
             LOG_INFO() <<
-                FMA_FMT("start building edge index for {}:{} in detached model", label, field);
+                FMA_FMT("end building edge index for {}:{} in detached model", label, field);
             return true;
         }
         // now build index

--- a/src/core/schema.cpp
+++ b/src/core/schema.cpp
@@ -408,45 +408,67 @@ void Schema::AddDetachedVertexProperty(KvTransaction& txn, VertexId vid, const V
 }
 
 Value Schema::GetDetachedVertexProperty(KvTransaction& txn, VertexId vid) {
-    return property_table_->GetValue(
+    auto ret = property_table_->GetValue(
         txn, graph::KeyPacker::CreateVertexPropertyTableKey(vid));
+    if (ret.Empty()) {
+        THROW_CODE(InternalError, "Get: vid {} is not found in the detached property table.", vid);
+    }
+    return ret;
 }
 
 void Schema::SetDetachedVertexProperty(KvTransaction& txn, VertexId vid, const Value& property) {
     auto ret = property_table_->SetValue(
         txn, graph::KeyPacker::CreateVertexPropertyTableKey(vid), property);
-    FMA_ASSERT(ret);
+    if (!ret) {
+        THROW_CODE(InternalError, "Set: vid {} is not found in the detached property table.", vid);
+    }
 }
 
 void Schema::DeleteDetachedVertexProperty(KvTransaction& txn, VertexId vid) {
     auto ret = property_table_->DeleteKey(
         txn, graph::KeyPacker::CreateVertexPropertyTableKey(vid));
-    FMA_ASSERT(ret);
+    if (!ret) {
+        THROW_CODE(InternalError, "Delete: vid {} is not found in the detached property table.", vid);
+    }
 }
 
 Value Schema::GetDetachedEdgeProperty(KvTransaction& txn, const EdgeUid& eid) {
-    return property_table_->GetValue(
+    auto ret = property_table_->GetValue(
         txn, graph::KeyPacker::CreateEdgePropertyTableKey(eid));
+    if (ret.Empty()) {
+        THROW_CODE(InternalError, "Get: euid {} is not found in the detached property table.",
+                   eid.ToString());
+    }
+    return ret;
 }
 
 void Schema::SetDetachedEdgeProperty(KvTransaction& txn, const EdgeUid& eid,
                                      const Value& property) {
     auto ret = property_table_->SetValue(
         txn, graph::KeyPacker::CreateEdgePropertyTableKey(eid), property);
-    FMA_ASSERT(ret);
+    if (!ret) {
+        THROW_CODE(InternalError, "Set: euid {} is not found in the detached property table.",
+                   eid.ToString());
+    }
 }
 
 void Schema::AddDetachedEdgeProperty(KvTransaction& txn, const EdgeUid& eid,
                                      const Value& property) {
     auto ret = property_table_->AddKV(
         txn, graph::KeyPacker::CreateEdgePropertyTableKey(eid), property);
-    FMA_ASSERT(ret);
+    if (!ret) {
+        THROW_CODE(InternalError, "Add: euid {} is found in the detached property table.",
+                   eid.ToString());
+    }
 }
 
 void Schema::DeleteDetachedEdgeProperty(KvTransaction& txn, const EdgeUid& eid) {
     auto ret = property_table_->DeleteKey(
         txn, graph::KeyPacker::CreateEdgePropertyTableKey(eid));
-    FMA_ASSERT(ret);
+    if (!ret) {
+        THROW_CODE(InternalError, "Delete: euid {} is not found in the detached property table.",
+                   eid.ToString());
+    }
 }
 
 // clear fields, other contents are kept untouched

--- a/src/core/schema.cpp
+++ b/src/core/schema.cpp
@@ -428,7 +428,8 @@ void Schema::DeleteDetachedVertexProperty(KvTransaction& txn, VertexId vid) {
     auto ret = property_table_->DeleteKey(
         txn, graph::KeyPacker::CreateVertexPropertyTableKey(vid));
     if (!ret) {
-        THROW_CODE(InternalError, "Delete: vid {} is not found in the detached property table.", vid);
+        THROW_CODE(InternalError, "Delete: vid {} is not found in the detached property table.",
+                   vid);
     }
 }
 

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -424,8 +424,11 @@ void Transaction::DeleteVertex(graph::VertexIterator& it, size_t* n_in, size_t* 
                     property = edge_schema->GetDetachedEdgeProperty(
                         *txn_, {vid, data.vid, data.lid, data.tid, data.eid});
                 }
-                edge_schema->DeleteEdgeIndex(*txn_, {vid, data.vid, data.lid, data.tid, data.eid},
-                                             property);
+                EdgeUid euid{vid, data.vid, data.lid, data.tid, data.eid};
+                edge_schema->DeleteEdgeIndex(*txn_, euid, property);
+                if (edge_schema->DetachProperty()) {
+                    edge_schema->DeleteDetachedEdgeProperty(*txn_, euid);
+                }
                 edge_delta_count_[data.lid]--;
                 if (fulltext_index_) {
                     edge_schema->DeleteEdgeFullTextIndex(
@@ -442,8 +445,11 @@ void Transaction::DeleteVertex(graph::VertexIterator& it, size_t* n_in, size_t* 
                     property = edge_schema->GetDetachedEdgeProperty(
                         *txn_, {data.vid, vid, data.lid, data.tid, data.eid});
                 }
-                edge_schema->DeleteEdgeIndex(*txn_, {data.vid, vid, data.lid, data.tid, data.eid},
-                                             property);
+                EdgeUid euid{data.vid, vid, data.lid, data.tid, data.eid};
+                edge_schema->DeleteEdgeIndex(*txn_, euid, property);
+                if (edge_schema->DetachProperty()) {
+                    edge_schema->DeleteDetachedEdgeProperty(*txn_, euid);
+                }
                 edge_delta_count_[data.lid]--;
                 if (fulltext_index_) {
                     edge_schema->DeleteEdgeFullTextIndex(

--- a/test/test_lgraph_api.cpp
+++ b/test/test_lgraph_api.cpp
@@ -1012,3 +1012,45 @@ TEST_F(TestLGraphApi, deleteLable) {
     UT_EXPECT_TRUE(db.DeleteVertexLabel("Person1"));
     check_dbs(6);
 }
+
+TEST_F(TestLGraphApi, deleteVertex) {
+    std::string path = "./testdb";
+    auto ADMIN = lgraph::_detail::DEFAULT_ADMIN_NAME;
+    auto ADMIN_PASS = lgraph::_detail::DEFAULT_ADMIN_PASS;
+    lgraph::AutoCleanDir cleaner(path);
+    Galaxy galaxy(path);
+    std::string db_path;
+    galaxy.SetCurrentUser(ADMIN, ADMIN_PASS);
+    GraphDB db = galaxy.OpenGraph("default");
+    VertexOptions vo("id");
+    vo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddVertexLabel("Person",
+                                     std::vector<FieldSpec>({{"id", FieldType::INT32, false}}),
+                                     vo));
+    EdgeOptions eo;
+    eo.detach_property = true;
+    UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
+                                   std::vector<FieldSpec>({{"id", FieldType::INT32, false}}),
+                                   eo));
+    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation","id", lgraph_api::IndexType::NonuniqueIndex));
+    std::vector<std::string> vp{"id"};
+    std::vector<std::string> ep{"id"};
+    auto txn = db.CreateWriteTxn();
+    auto vid1 = txn.AddVertex(std::string("Person"), vp, {FieldData::Int32(1)});
+    auto vid2 = txn.AddVertex(std::string("Person"), vp, {FieldData::Int32(2)});
+    auto euid = txn.AddEdge(vid1, vid2, std::string("Relation"), ep, {FieldData::Int32(1)});
+    auto iter1 = txn.GetVertexIterator(vid1);
+    iter1.Delete();
+    auto v_schema = (lgraph::Schema*)txn.GetTxn()->GetSchema("Person", true);
+    UT_EXPECT_THROW_CODE(v_schema->GetDetachedVertexProperty(txn.GetTxn()->GetTxn(), vid1),
+                         InternalError);
+    UT_EXPECT_NO_THROW(v_schema->GetDetachedVertexProperty(txn.GetTxn()->GetTxn(), vid2));
+    auto e_schema = (lgraph::Schema*)txn.GetTxn()->GetSchema("Relation", false);
+    UT_EXPECT_THROW_CODE(e_schema->GetDetachedEdgeProperty(txn.GetTxn()->GetTxn(), euid),
+                         InternalError);
+    auto iter2 = txn.GetVertexIterator(vid2);
+    iter2.Delete();
+    UT_EXPECT_THROW_CODE(v_schema->GetDetachedVertexProperty(txn.GetTxn()->GetTxn(), vid2),
+                         InternalError);
+    txn.Commit();
+}

--- a/test/test_lgraph_api.cpp
+++ b/test/test_lgraph_api.cpp
@@ -1032,7 +1032,7 @@ TEST_F(TestLGraphApi, deleteVertex) {
     UT_EXPECT_TRUE(db.AddEdgeLabel("Relation",
                                    std::vector<FieldSpec>({{"id", FieldType::INT32, false}}),
                                    eo));
-    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation","id", lgraph_api::IndexType::NonuniqueIndex));
+    UT_EXPECT_TRUE(db.AddEdgeIndex("Relation", "id", lgraph_api::IndexType::NonuniqueIndex));
     std::vector<std::string> vp{"id"};
     std::vector<std::string> ep{"id"};
     auto txn = db.CreateWriteTxn();


### PR DESCRIPTION
During deleting a vertex, the edges associated with the vid also be deleted. If the edge label is in detached model， the edge key should also be deleted in property table. This pr fix this.